### PR TITLE
Remove unneeded check

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/prl/documentgenerator/PdfGenerationServiceConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/prl/documentgenerator/PdfGenerationServiceConsumerTest.java
@@ -90,7 +90,6 @@ public class PdfGenerationServiceConsumerTest {
                   "application/vnd.uk.gov.hmcts.pdf-service.v2+json;charset=UTF-8")
             .path("/pdfs")
             .willRespondWith()
-            .withBinaryData("".getBytes(), "application/octet-stream")
             .matchHeader(org.springframework.http.HttpHeaders.CONTENT_TYPE,
                          "application/pdf")
             .status(HttpStatus.SC_OK)


### PR DESCRIPTION
- This is causing failure when upgrading pact on provider.
- This is not relevant anyway as the next line checks content type match

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
