### PR TITLE
Bump org.springdoc:springdoc-openapi-ui from 1.6.9 to 1.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,7 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
     implementation group: 'com.puppycrawl.tools', name: 'checkstyle', version:  versions.puppyCrawl
     implementation group: 'commons-io', name: 'commons-io', version: versions.commonsIo
-    implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.9'
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.8.0'
 
   implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 


### PR DESCRIPTION
Bumps org.springdoc:springdoc-openapi-ui from 1.6.9 to 1.8.0.

---
updated-dependencies:
- dependency-name: org.springdoc:springdoc-openapi-ui dependency-type: direct:production update-type: version-update:semver-minor ...

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] the enable_keep_helm label has been added, if the helm release should be persisted after a successful build

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
