### PR TITLE
Bump apache commons io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ jacoco {
 }
 
 def versions = [
-    commonsIo: '2.7',
+    commonsIo: '2.19.0',
     commonsLang3: '3.9',
     commonsBeanUtils: '1.9.4',
     feignHttpClient: '10.2.0',

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -21,5 +21,12 @@
     <cve>CVE-2025-48988</cve>
     <cve>CVE-2025-46701</cve>
   </suppress>
+  <suppress>
+   <notes><![CDATA[
+   file name: commons-configuration-1.8.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/commons\-configuration/commons\-configuration@.*$</packageUrl>
+   <cpe>cpe:/a:apache:commons_configuration</cpe>
+</suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
TBC


### Change description ###
 - Resolves CVEs by upgrading commons io
  - Suppress configuration, we don't load configurations using the library, is included by spring-cloud-starter-netflix-ribbon which doesn't have any upgrade yet - should look and see if required in future work


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
