### PR TITLE
FPVTL-2883 upgrade to java-logging 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -291,8 +291,7 @@ dependencies {
     implementation group: 'org.springframework.hateoas', name: 'spring-hateoas', version: versions.springHateoas
     implementation group: 'org.apache.commons', name: 'commons-lang3', version : versions.commonsLang3
 
-    implementation 'com.github.hmcts.java-logging:logging:6.1.9'
-    implementation 'com.github.hmcts.java-logging:logging-appinsights:6.1.9'
+    implementation 'com.github.hmcts.java-logging:logging:8.0.0'
     implementation group: 'org.springframework', name: 'spring-context-support', version: versions.springFramework
     implementation ( group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: versions.serviceTokenGenerator) {
         exclude group: 'io.reactivex', module: 'io.reactivex'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPVTL-2883

### Change description ###
Upgrade to java-logging 8 because all previous versions will become outdated and PRs would not build after 01/06/2026 
In versions prior to 7.x, there was a separate dependency for appinsights. This is part of the main dependency since 7.0.0. That line has been removed here because java-logging was at version 6.1.9

These are the instructions to upgrade from 6.x: https://github.com/hmcts/java-logging See the readme file there.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
